### PR TITLE
Fix xtable items order issue

### DIFF
--- a/packages/basic/src/components/XTable/index.vue
+++ b/packages/basic/src/components/XTable/index.vue
@@ -25,12 +25,12 @@
           </div>
         </td>
         <td
-          v-for="(val, key) in props.item"
-          :key="key"
-          v-if="key !== 'value' && checkHeaderKey(key)"
+          v-for="{ value: columnName, render } in columns"
+          :key="columnName"
+          v-if="columnName !== 'action'"
         >
-          <div class="td-wrapper" :class="`${key}-td-wrapper`">
-            <div v-html="!checkHeaderRender(key) ? val : checkHeaderRender(key)(props.item)"></div>
+          <div class="td-wrapper" :class="`${columnName}-td-wrapper`">
+            <div v-html="render ? render(props.item) : props.item[columnName]"></div>
           </div>
         </td>
 
@@ -123,20 +123,6 @@ export default {
       if (!this.itemKeys.has(item))
         this.itemKeys.set(item, ++this.currentItemKey);
       return this.itemKeys.get(item);
-    },
-
-    checkHeaderKey(key) {
-      return this.headers.some((item) => {
-        return item.value === key;
-      });
-    },
-
-    checkHeaderRender(key) {
-      const result = this.headers.find((item) => {
-        return item.value === key;
-      });
-
-      return (result && result.render) || false;
     },
 
     checkRender(btn, item) {

--- a/packages/basic/src/pages/xtable.vue
+++ b/packages/basic/src/pages/xtable.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class='contentWrapper'>
+    <x-table v-bind='schema' />
+  </div>
+</template>
+
+<script>
+import XTable from '../components/XTable';
+
+export default {
+  name: 'xtable-page',
+  components: {
+    XTable
+  },
+  computed: {},
+  data: function() {
+    return {
+      schema: {
+        headers: [
+          { value: 'no', text: 'No' },
+          {
+            value: 'name',
+            text: 'Name',
+            render: (item) => {
+              const { description, name } = item;
+              return `<div class="tooltip"> ${name}
+            <i class="material-icons infoIcon color-primary position-relative" style="top:3px; opacity:.6">more</i>
+            <span class="tooltiptext"> ${description} </span></div>`;
+            }
+          },
+          { value: 'age', text: 'Age' },
+          { value: 'action', text: 'Actions' }
+        ],
+        items: [
+          {
+            no: '1',
+            age: '30',
+            name: 'John',
+            description: 'He has been single for 30 years'
+          }
+        ],
+        actions: [
+          {
+            content: 'edit',
+            square: true,
+            outline: true,
+            borderRadius: 4,
+            color: '#666',
+            render: (item) => true,
+            click: (item) => {
+              this.$router.push({
+                name: 'taskEdit',
+                params: { task: item }
+              });
+            }
+          },
+          {
+            content: 'delete_outline',
+            square: true,
+            outline: true,
+            borderRadius: 4,
+            color: '#D0707B',
+            class: 'actionWarning',
+            render: (item) => false,
+            click: (item) => {
+              console.log(item);
+            }
+          }
+        ]
+      }
+    };
+  }
+};
+</script>
+
+<style>
+.contentWrapper {
+  width: 100%;
+  max-width: 600px;
+  margin: auto;
+}
+</style>


### PR DESCRIPTION
Issue description:

Before this PR, the table looks like this:
![screen shot 2019-01-30 at 5 37 38 pm](https://user-images.githubusercontent.com/4949470/51972159-c720b200-24b5-11e9-942f-fd92e57e2d0c.png)
with table schema (Note that the order of **age** and **name**):
```
      schema: {
        headers: [
          { value: 'no', text: 'No' },
          { value: 'name', text: 'Name' },
          { value: 'age', text: 'Age' },
          { value: 'action', text: 'Actions' }
        ],
        items: [
          {
            no: '1',
            age: '30',
            name: 'John',
            description: 'He has been single for 30 years'
          }
        ],
        actions: [ ...  ]
      }
```

The order of data should not depends on the attributes of the item object.