### PR TITLE
forEach has been with replaced with for in

### DIFF
--- a/packages/dateTimePicker/src/build.js
+++ b/packages/dateTimePicker/src/build.js
@@ -18,9 +18,9 @@ export function install(Vue) {
   if (install.installed) return;
   install.installed = true;
 
-  Components.forEach(component => {
-    Vue.component(component.name, component);
-  });
+  for(const Key in Components) {
+    Vue.component(Components[Key].name, Components[Key]);
+  }
 }
 
 // Create module definition for Vue.use()


### PR DESCRIPTION
Problem: After installing the script from npm and attaching it (like in the given example), there appeared a error in the console.
Error: Uncaught TypeError: Components.forEach is not a function
Happens becouse: Components is not an array and forEach does not work on json objects.
Fix: replace Components.forEach with for in

Steps to reproduce:
1. Install vue
2. Install lazy-copilot/datetimepicker (npm i @lazy-copilot/datetimepicker)
3. attach script like in the given example
4. open console