### PR TITLE
Object.values added to install function

### DIFF
--- a/packages/dateTimePicker/src/build.js
+++ b/packages/dateTimePicker/src/build.js
@@ -18,8 +18,8 @@ export function install(Vue) {
   if (install.installed) return;
   install.installed = true;
 
-  Components.forEach(component => {
-    Vue.component(component.name, component);
+  Object.values(Components).forEach(Component => {
+    Vue.component(Component.name, Component);
   });
 }
 


### PR DESCRIPTION
Problem: After installing the script from npm and attaching it (like in the given example), there appeared a error in the console.
Error: Uncaught TypeError: Components.forEach is not a function
Happend becouse: Components is not an array and forEach does not work on json objects.
Fix: make the object iterable by adding Object.values

Steps to reproduce: 
1. Install vue 
2. Install lazy-copilot/datetimepicker (npm i @lazy-copilot/datetimepicker)
3. attach script like in the given example
4. open console